### PR TITLE
Launch Replay Player Directly With a Replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Optionally, select a folder where the replays of each battle will be saved. By d
 At the main window specify two fleets to battle each other, to do this, select the fleet's "Root Folder" as described in [Combat Simulator](https://github.com/martindevans/Yolol-SpaceShipCombatSimulator/blob/master/readme.md#Folder-Structure). When both fleets are selected, the "Simulate!" button becomes enabled. Press it to run the battle. While the battle simulator is running, the "Copy Replay Path" and "Open Player" buttons are disabled - they are enabled once the battle simulator has finished.
 
 ##### Viewing the Latest Replay
-After the battle has finished, press the "Copy Replay Path" button, and paste it into the "Replay File Path" field of the [Replay Player](https://github.com/martindevans/Yolol-SpaceCombatPlayer) to view.
+After the battle has finished, press the "Watch Replay" button to view it in the [Replay Player](https://github.com/martindevans/Yolol-SpaceCombatPlayer).

--- a/YololFleetsGUI/Form1.Designer.cs
+++ b/YololFleetsGUI/Form1.Designer.cs
@@ -37,8 +37,7 @@ namespace YololFleetsGUI
             this.btnSettings = new System.Windows.Forms.Button();
             this.rtbConsoleOutput = new System.Windows.Forms.RichTextBox();
             this.lblWinner = new System.Windows.Forms.Label();
-            this.btnCopyReplayPath = new System.Windows.Forms.Button();
-            this.btnOpenPlayer = new System.Windows.Forms.Button();
+            this.btnWatchReplay = new System.Windows.Forms.Button();
             this.saveReplayDialog = new System.Windows.Forms.FolderBrowserDialog();
             this.SuspendLayout();
             // 
@@ -133,29 +132,18 @@ namespace YololFleetsGUI
             this.lblWinner.TabIndex = 8;
             this.lblWinner.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // btnCopyReplayPath
+            // btnWatchReplay
             // 
-            this.btnCopyReplayPath.Enabled = false;
-            this.btnCopyReplayPath.Location = new System.Drawing.Point(106, 159);
-            this.btnCopyReplayPath.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.btnCopyReplayPath.Name = "btnCopyReplayPath";
-            this.btnCopyReplayPath.Size = new System.Drawing.Size(138, 31);
-            this.btnCopyReplayPath.TabIndex = 9;
-            this.btnCopyReplayPath.Text = "Copy Replay Path";
-            this.btnCopyReplayPath.UseVisualStyleBackColor = true;
-            this.btnCopyReplayPath.Click += new System.EventHandler(this.btnCopyReplayPath_Click);
-            // 
-            // btnOpenPlayer
-            // 
-            this.btnOpenPlayer.Enabled = false;
-            this.btnOpenPlayer.Location = new System.Drawing.Point(250, 159);
-            this.btnOpenPlayer.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.btnOpenPlayer.Name = "btnOpenPlayer";
-            this.btnOpenPlayer.Size = new System.Drawing.Size(106, 31);
-            this.btnOpenPlayer.TabIndex = 10;
-            this.btnOpenPlayer.Text = "Open Player";
-            this.btnOpenPlayer.UseVisualStyleBackColor = true;
-            this.btnOpenPlayer.Click += new System.EventHandler(this.btnOpenPlayer_Click);
+            this.btnWatchReplay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnWatchReplay.Enabled = false;
+            this.btnWatchReplay.Location = new System.Drawing.Point(432, 159);
+            this.btnWatchReplay.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnWatchReplay.Name = "btnWatchReplay";
+            this.btnWatchReplay.Size = new System.Drawing.Size(131, 31);
+            this.btnWatchReplay.TabIndex = 10;
+            this.btnWatchReplay.Text = "Watch Replay";
+            this.btnWatchReplay.UseVisualStyleBackColor = true;
+            this.btnWatchReplay.Click += new System.EventHandler(this.btnWatchReplay_Click);
             // 
             // saveReplayDialog
             // 
@@ -167,8 +155,7 @@ namespace YololFleetsGUI
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.ClientSize = new System.Drawing.Size(577, 773);
-            this.Controls.Add(this.btnOpenPlayer);
-            this.Controls.Add(this.btnCopyReplayPath);
+            this.Controls.Add(this.btnWatchReplay);
             this.Controls.Add(this.lblWinner);
             this.Controls.Add(this.rtbConsoleOutput);
             this.Controls.Add(this.btnSettings);
@@ -193,8 +180,7 @@ namespace YololFleetsGUI
         private System.Windows.Forms.Button btnSettings;
         private System.Windows.Forms.RichTextBox rtbConsoleOutput;
         private System.Windows.Forms.Label lblWinner;
-        private System.Windows.Forms.Button btnCopyReplayPath;
-        private System.Windows.Forms.Button btnOpenPlayer;
+        private System.Windows.Forms.Button btnWatchReplay;
         private System.Windows.Forms.FolderBrowserDialog saveReplayDialog;
     }
 }

--- a/YololFleetsGUI/Form1.cs
+++ b/YololFleetsGUI/Form1.cs
@@ -56,7 +56,7 @@ namespace YololFleetsGUI
                 {
                     btnRunBattleSimulation.Enabled = false;
 
-                    EnableDisableReplayButtons(false);
+                    btnWatchReplay.Enabled = false;
 
                     StopProcess(combatSimulator, combatSimulatorRunning);
 
@@ -100,6 +100,7 @@ namespace YololFleetsGUI
             settings.Focus();
         }
 
+        #region deprecated
         //no longer used
         /*private void btnSaveReplay_Click(object sender, EventArgs e)
         {
@@ -130,12 +131,13 @@ namespace YololFleetsGUI
             }
         }*/
 
-        private void btnCopyReplayPath_Click(object sender, EventArgs e)
+        /*private void btnCopyReplayPath_Click(object sender, EventArgs e)
         {
             Clipboard.SetText(Path.Combine(latestReplayPath,Preferences.defaultReplayFileName));
-        }
+        }*/
+        #endregion
 
-        private void btnOpenPlayer_Click(object sender, EventArgs e)
+        private void btnWatchReplay_Click(object sender, EventArgs e)
         {
             string playerPath = Preferences.current.ReplayPlayerFilePath;
 
@@ -147,6 +149,7 @@ namespace YololFleetsGUI
 
                     replayPlayer = new Process();
                     replayPlayer.StartInfo.FileName = playerPath;
+                    replayPlayer.StartInfo.Arguments = Path.Combine(latestReplayPath, Preferences.defaultReplayFileName);
                     replayPlayer.EnableRaisingEvents = true;
 
                     replayPlayer.Exited += new EventHandler(ReplayPlayerExited);
@@ -184,14 +187,6 @@ namespace YololFleetsGUI
                     p.Kill();
                 }
             }
-        }
-
-        private void EnableDisableReplayButtons(bool enable)
-        {
-            //btnSaveReplay.Enabled = enable;
-            btnCopyReplayPath.Enabled = enable;
-            btnOpenPlayer.Enabled = enable;
-
         }
 
         private static string DateTimeToString (DateTime dt)
@@ -247,7 +242,7 @@ namespace YololFleetsGUI
         {
             this.BeginInvoke(new MethodInvoker(() =>
             {
-                EnableDisableReplayButtons(true);
+                btnWatchReplay.Enabled = true;
                 combatSimulatorRunning = false;
 
                 SaveTempReplayToDefaultReplayFolder();

--- a/YololFleetsGUI/Settings.Designer.cs
+++ b/YololFleetsGUI/Settings.Designer.cs
@@ -182,7 +182,7 @@ namespace YololFleetsGUI
             this.lblVersion.Name = "lblVersion";
             this.lblVersion.Size = new System.Drawing.Size(72, 20);
             this.lblVersion.TabIndex = 14;
-            this.lblVersion.Text = "Version: 2";
+            this.lblVersion.Text = "Version: 3";
             // 
             // Settings
             // 


### PR DESCRIPTION
"Watch Replay" button now launches the replay player directly with the replay - requires V11 or later of the replay player, recommended V12 or later
"Copy Replay Path" button became unneccessary and was thus was removed